### PR TITLE
feat: 業務紹介ページの作成

### DIFF
--- a/src/app/(pages)/job-info/page.tsx
+++ b/src/app/(pages)/job-info/page.tsx
@@ -1,0 +1,28 @@
+import JobIntroduction from "@/app/components/jobIntroduction"
+
+const jobIntroductionPage = () => {
+  return (
+    <div className="my-[5%] pt-[55px] pb-[30px] bg-[#F0EBDC]">
+          <div className="left_side fixed top-[280px] left-[7px] ml-1 hidden [writing-mode:vertical-rl] lg:block">
+            <p>AIM COMMONS</p>
+          </div>
+          <div className="right_side fixed top-[280px] right-[7px] mr-1 hidden      [writing-mode:vertical-rl] lg:block">
+            <p>AIM COMMONS</p>
+        </div>
+
+      <div className="text-base text-[#d9ae4c] text-center font-bold mb-5">JOB INTRODUCTION</div>
+      <div className="text-3xl text-black text-center font-semibold mb-5">業務紹介</div>
+      <div className="text-lg text-black text-center font-bold">受付で常駐している学生スタッフの業務をご紹介します</div>
+
+        <div className="bg-white mx-[3%] mt-[1%] rounded-md grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <JobIntroduction image="/images/IMG_0091.JPG" alt = "test" title="PC貸出" text='ICTを用いた学びを支援するカメラや充電器、ブースの貸出を行います。貸出機器の一覧は<a href="https://www.google.co.jp/" target=blank class="text-blue-500 underline">こちら</a>'/>
+            <JobIntroduction image="/images/floor01.jpg" alt = "test" title="機器貸出" text="ICTを用いた学びを支援するカメラや充電器、ブースの貸出を行います。貸出機器の一覧はこちら"/>
+            <JobIntroduction image="/images/floor01.jpg" alt = "test" title="test" text="test"/>
+            <JobIntroduction image="/images/floor01.jpg" alt = "test" title="test" text="test"/>
+        </div>
+    </div>
+  );
+};
+
+export default jobIntroductionPage;
+

--- a/src/app/(pages)/job-intro/page.tsx
+++ b/src/app/(pages)/job-intro/page.tsx
@@ -1,0 +1,28 @@
+import JobIntroduction from "@/app/components/jobIntroduction"
+
+const jobIntroductionPage = () => {
+  return (
+    <div className="my-[5%] pt-[55px] pb-[30px] bg-[#F0EBDC]">
+          <div className="left_side fixed top-[280px] left-[7px] ml-1 hidden [writing-mode:vertical-rl] lg:block">
+            <p>AIM COMMONS</p>
+          </div>
+          <div className="right_side fixed top-[280px] right-[7px] mr-1 hidden      [writing-mode:vertical-rl] lg:block">
+            <p>AIM COMMONS</p>
+        </div>
+
+      <div className="text-base text-[#d9ae4c] text-center font-bold mb-5">JOB INTRODUCTION</div>
+      <div className="text-3xl text-black text-center font-semibold mb-5">業務紹介</div>
+      <div className="text-lg text-black text-center font-bold">受付で常駐している学生スタッフの業務をご紹介します</div>
+
+        <div className="bg-white mx-[3%] mt-[1%] rounded-md grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <JobIntroduction image="/images/IMG_0091.JPG" alt = "test" title="PC貸出" text='ICTを用いた学びを支援するカメラや充電器、ブースの貸出を行います。貸出機器の一覧は<a href="https://www.google.co.jp/" target=blank class="text-blue-500 underline">こちら</a>'/>
+            <JobIntroduction image="/images/floor01.jpg" alt = "test" title="機器貸出" text="ICTを用いた学びを支援するカメラや充電器、ブースの貸出を行います。貸出機器の一覧はこちら"/>
+            <JobIntroduction image="/images/floor01.jpg" alt = "test" title="test" text="test"/>
+            <JobIntroduction image="/images/floor01.jpg" alt = "test" title="test" text="test"/>
+        </div>
+    </div>
+  );
+};
+
+export default jobIntroductionPage;
+

--- a/src/app/components/jobIntroduction.tsx
+++ b/src/app/components/jobIntroduction.tsx
@@ -1,0 +1,35 @@
+import Image from "next/image";
+
+type Props = {
+  image: string;
+  alt: string;
+  title: string;
+  text: string;
+};
+
+const JobIntroduction = ({ image, alt, title, text }: Props) => {
+  return (
+    <div className="flex flex-col bg-white rounded-md p-4 mx-[8%] my-[8%]">
+      {/* 画像の表示 */}
+      <div className="w-full mb-4">
+        <Image 
+          src={image} 
+          alt={alt} 
+          layout="intrinsic" 
+          width={640}       
+          height={360}      
+          className="rounded-md"
+        />
+      </div>
+      {/* テキストエリア */}
+      <div className="text-left">
+        <div className="text-xl font-bold mb-2">{title}</div>
+        <div className="text-sm" dangerouslySetInnerHTML={{ __html: text }}></div>
+      </div>
+    </div>
+  );
+};
+
+export default JobIntroduction;
+
+


### PR DESCRIPTION
## チェック
- [x] 余計な差分は存在しないか？

## 実装内容
業務紹介ページの作成

## スクショ
<img width="1396" alt="image" src="https://github.com/user-attachments/assets/c2ad2d84-291d-4654-ae68-52c9d62f2ce3" />


## issue
close #10 

## 懸念点
画像と文章は、まだ会議の承認をもらっていません。再度プルリクを出して差し替え予定です。