### PR TITLE
Fix/aim o kohei/typo ramen

### DIFF
--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -48,7 +48,7 @@ export default function Header() {
 									</li>
 								))}
 								<li className={cn("px-5 py-3")}>
-									<Link href={"https://docs.google.com/spreadsheets/d/1pGRuvjajI833WFWqME8QbjGkraUQzgZ-Fp241Tbu7I8/edit?gid=0#gid=0"} target="_blank">貸出機器一蘭</Link>
+									<Link href={"https://docs.google.com/spreadsheets/d/1pGRuvjajI833WFWqME8QbjGkraUQzgZ-Fp241Tbu7I8/edit?gid=0#gid=0"} target="_blank">貸出機器一覧</Link>
 								</li>
 								<li className={cn("px-5 py-3")}>
 									<Link href={"https://www.aim.aoyama.ac.jp/customer_support/"} target="_blank">お問い合わせ</Link>

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -51,6 +51,9 @@ export default function Header() {
 									<Link href={"https://docs.google.com/spreadsheets/d/1pGRuvjajI833WFWqME8QbjGkraUQzgZ-Fp241Tbu7I8/edit?gid=0#gid=0"} target="_blank">貸出機器一覧</Link>
 								</li>
 								<li className={cn("px-5 py-3")}>
+									<Link href={"https://ima-sc.notion.site/7fd23df752674abb95261bdc54b3de28"} target="_blank">ワークショップ</Link>
+								</li>
+								<li className={cn("px-5 py-3")}>
 									<Link href={"https://www.aim.aoyama.ac.jp/customer_support/"} target="_blank">お問い合わせ</Link>
 								</li>
 							</ul>


### PR DESCRIPTION
## チェック
- [x] 余計な差分は存在しないか？

## 実装内容
- ヘッダーの誤字を修正（一蘭 → 一覧）
- ヘッダーにワークショップ案内のNortionのURLを追加

## スクショ
<img width="371" alt="image" src="https://github.com/user-attachments/assets/12135687-fa1e-4e66-bb11-dcccdc4d0d53" />

## issue
close 

## 懸念点
