### PR TITLE
fix: 青山情報削除に伴うレイアウト変更

### DIFF
--- a/src/app/components/time.tsx
+++ b/src/app/components/time.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 const Time = ({ title, notes, subtitle, locations }: Props) => {
 	return (
-		<div className=" h-[510px] rounded-lg bg-white p-6">
+		<div className="rounded-lg bg-white p-6">
 			<div className="mb-4 border-b text-center">
 				<Title maintitle={title} subtitle={subtitle} notes={notes} />
 			</div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -122,29 +122,37 @@ const TopPage = async () => {
 			<h1 className="mt-12 mb-8 text-center font-bold text-xl md:text-[26px]">
 				インフォメーション
 			</h1>
-			<div className="grid gap-4 lg:gap-8 xl:grid-cols-[4fr_6fr]">
+			<div className="grid gap-4 lg:grid-cols-[4fr_6fr] xl:grid-cols-[4fr_6fr]">
 				{/* 開室時間の表示 */}
-				<Time
-					title="開室時間"
-					notes="※授業実施日のみ"
-					subtitle="OPENING HOURS"
-					locations={[
-						{ id: "sagamihara", name: "開室時間", time: "9:00 - 20:00" },
-						{
-							id: "sagamihara-open",
-							name: "受付時間",
-							time: "9:45 - 16:45",
-						},
-					]}
-				/>
-
-				{/* お知らせの表示 */}
-				<Information
-					title="お知らせ"
-					notes=""
-					subtitle="INFORMATION"
-					content={informationContent}
-				/>
+				<div>
+					<Time
+						title="開室時間"
+						notes="※授業実施日のみ"
+						subtitle="OPENING HOURS"
+						locations={[
+							{ id: "sagamihara", name: "開室時間", time: "9:00 - 20:00" },
+							{
+								id: "sagamihara-open",
+								name: "受付時間",
+								time: "9:45 - 16:45",
+							},
+							{
+								id: "sagamihara-open",
+								name: "PC貸出時間",
+								time: "9:45 - 16:30",
+							},
+						]}
+					/>
+				</div>
+				<div>
+					{/* お知らせの表示 */}
+					<Information
+						title="お知らせ"
+						notes=""
+						subtitle="INFORMATION"
+						content={informationContent}
+					/>
+				</div>
 			</div>
 
 			<div className="gap-4 text-center ">


### PR DESCRIPTION
## チェック
- [ ] 余計な差分は存在しないか？

## 実装内容
時間部分の要素が減ったことにより、レイアウトの変更があったので、高さなどを合わせて実装しました
レスポンシブ対応も済んでいます

## スクショ
<img width="1430" alt="スクリーンショット 2025-04-24 13 01 35" src="https://github.com/user-attachments/assets/a5d2640c-c979-4bfe-845a-8f075dcf1e01" />
<img width="376" alt="スクリーンショット 2025-04-24 13 02 48" src="https://github.com/user-attachments/assets/42460acd-1b4c-4bd3-bfe7-20cd8e104ba0" />


## issue
close 

## 懸念点
