### PR TITLE
Fix/aim skanoka/fix responsive

### DIFF
--- a/src/app/components/article.tsx
+++ b/src/app/components/article.tsx
@@ -119,9 +119,9 @@ export default function Article({ content }: { content: ArticleType }) {
 		<div className="container mx-auto min-h-[60vh] rounded-xl bg-white py-[8%]">
 			<div className="mx-[8%]">
 				<h1 className="mb-4 font-bold text-2xl lg:text-3xl">{content.title}</h1>
-				<div className="mb-2 flex justify-between">
+				<div className="mb-2 block justify-between md:flex">
 					<Tag tags={content.tags} variant="article" />
-					<h2 className="text-right font-semibold text-gray-600">
+					<h2 className="text-right font-semibold text-gray-600 text-lg md:text-lg">
 						{format(content.publishedAt || content.updatedAt, "yyyy.MM.dd")}
 					</h2>
 				</div>

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -32,7 +32,7 @@ export default function Header() {
 								<AlignJustify />
 							</Button>
 						</SheetTrigger>
-						<SheetContent>
+						<SheetContent className="max-h-screen overflow-y-auto pb-10">
 							<a href="/" className="inline-block w-fit">
 								<Image
 									src="/images/nav_logo.svg"
@@ -44,14 +44,14 @@ export default function Header() {
 							</a>
 							<SheetHeader className="mb-[10px] h-[20px] border-b" />
 
-							<p className="my-3 font-bold text-stone-400">
+							<p className="my-3 font-bold text-[0.7em] text-sm text-stone-400 sm:text-base ">
 								AIM Commonsを初めて使う方へ
 							</p>
 							<ul>
-								<li className={cn("px-5 py-3")}>
+								<li className={cn("px-5 py-3 text-[0.7em] sm:text-base")}>
 									<a href={"/introduce"}>利用案内</a>
 								</li>
-								<li className={cn("px-5 py-3")}>
+								<li className={cn("px-5 py-3 text-[0.7em] sm:text-base")}>
 									<a
 										href={
 											"https://docs.google.com/spreadsheets/d/1pGRuvjajI833WFWqME8QbjGkraUQzgZ-Fp241Tbu7I8/edit?gid=0#gid=0"
@@ -61,19 +61,19 @@ export default function Header() {
 										className="flex items-center gap-1"
 									>
 										貸出機器一覧
-										<FontAwesomeIcon icon={faLink} className="size-5" />
+										<FontAwesomeIcon icon={faLink} className="size-3 md:size-5" />
 									</a>
 								</li>
 							</ul>
 							<SheetHeader className="mb-[10px] h-[20px] border-b" />
-							<p className="my-3 font-bold text-stone-400">
+							<p className="my-3 font-bold text-[0.7em] text-stone-400 sm:text-base">
 								AIM Commonsを使いこなしたい方へ
 							</p>
-							<p className="my-2 ml-2 font-bold text-stone-400">
+							<p className="my-2 ml-2 font-bold text-[0.7em] text-stone-400 sm:text-base">
 								ワークショップ
 							</p>
 							<ul className="mb-1">
-								<li className={cn("px-5 py-3")}>
+								<li className={cn("px-5 py-3 text-[0.7em] sm:text-base")}>
 									<a
 										href={
 											"https://ima-sc.notion.site/7fd23df752674abb95261bdc54b3de28"
@@ -83,30 +83,31 @@ export default function Header() {
 										className="flex items-center gap-1"
 									>
 										ワークショップ (相模原キャンパス)
-										<FontAwesomeIcon icon={faLink} className="size-5" />
+										<FontAwesomeIcon icon={faLink} className="size-3 md:size-5" />
 									</a>
 								</li>
 							</ul>
-							<p className="my-2 ml-2 font-bold text-stone-400">
+							<p className="my-2 ml-2 font-bold text-[0.7em] text-stone-400 sm:text-base">
 								AIM Commonsからの情報発信
 							</p>
 							<ul>
-								<li className={cn("px-5 py-3")}>
+								<li className={cn("px-5 py-3 text-[0.7em] sm:text-base")}>
 									<a href={"/info"}>お知らせ</a>
 								</li>
-								<li className={cn("px-5 py-3")}>
+								<li className={cn("px-5 py-3 text-[0.7em] sm:text-base")}>
 									<a href={"/movies"}>YouTube動画</a>
 								</li>
-								<li className={cn("px-5 py-3")}>
+								<li className={cn("px-5 py-3 text-[0.7em] sm:text-base")}>
 									<a href={"/blog"}>業務ブログ</a>
 								</li>
 							</ul>
 							<SheetHeader className="mb-[10px] h-[20px] border-b" />
-							<p className="my-3 font-bold text-stone-400">
+							{/* biome-ignore lint/nursery/useSortedClasses: <explanation> */}
+<p className="my-3 font-bold text-stone-400 text-[0.7em] sm:text-base">
 								もっとAIM Commonsに関わりたい方へ
 							</p>
 							<ul>
-								<li className={cn("px-5 py-3")}>
+								<li className={cn("px-5 py-3 text-[0.7em] sm:text-base")}>
 									<a href={"/recruit"}>学生スタッフ採用</a>
 								</li>
 							</ul>

--- a/src/app/components/tag.tsx
+++ b/src/app/components/tag.tsx
@@ -14,7 +14,7 @@ export default function Tag({
 			: "p-1 px-3 rounded-full h-fit w-fit bg-[#d9ae4c] text-sm shadow-sm cursor-pointer font-bold";
 
 	return (
-		<div className="flex h-6 flex-wrap gap-2 text-white text-xs">
+		<div className="flex flex-wrap gap-2 text-white text-xs">
 			{tags.length > 0 ? (
 				tags.map((tag) => (
 					<Link href={`/category/${tag.path}/1`} key={tag.title} legacyBehavior>


### PR DESCRIPTION
## チェック
- [ ] 余計な差分は存在しないか？

## 実装内容
- ハンバーガーメニューの項目がスマホ画面だと大きすぎたので、小さくしました
- ハンバーガーメニュー内でのスクロールができなかったので、できるようにしました
- お知らせページのタグがスマホ画面だと縦並びになってしまっていたので、横並びにし、日付を１段下げました

## スクショ
<img width="362" alt="スクリーンショット 2025-05-09 16 19 21" src="https://github.com/user-attachments/assets/9396c705-d6df-4a03-954a-9a86d464c02e" />

お知らせページ
<img width="362" alt="スクリーンショット 2025-05-09 16 20 23" src="https://github.com/user-attachments/assets/ad4270f0-9570-416b-90d3-e9e26baaaae5" />

## issue
close 

## 懸念点
