### PR TITLE
feat: 採用ページメタタグ実装

### DIFF
--- a/src/app/(pages)/recruit/page.tsx
+++ b/src/app/(pages)/recruit/page.tsx
@@ -3,6 +3,12 @@ import JobIntroduction from "@/app/components/jobIntroduction";
 import Title from "@/app/components/title";
 import Image from "next/image";
 import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+	title: "学生スタッフ採用",
+	description: "AIM Commonsの採用情報を紹介します",
+};
 
 const jobIntroductionPage = () => {
 	return (


### PR DESCRIPTION
## チェック
- [x] 余計な差分は存在しないか？

## 実装内容
採用ページにメタタグを実装

## スクショ
<img width="231" alt="image" src="https://github.com/user-attachments/assets/f42838c8-2829-4b3b-a1b7-b6ba648c8603" />

## issue
close 

## 懸念点
