### PR TITLE
fix: タイムゾーン・土日を考慮

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
 		"src/*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}": [
 			"biome format --write ./src",
 			"biome lint --write ./src"
-			
 		]
 	},
 	"dependencies": {
@@ -30,6 +29,7 @@
 		"class-variance-authority": "^0.7.0",
 		"clsx": "^2.1.1",
 		"date-fns": "^4.1.0",
+		"date-fns-tz": "^3.2.0",
 		"fast-xml-parser": "^4.5.0",
 		"highlight.js": "^11.11.1",
 		"html-react-parser": "^5.1.18",

--- a/src/app/components/userDisplay/userDisplay.tsx
+++ b/src/app/components/userDisplay/userDisplay.tsx
@@ -1,7 +1,7 @@
 import { faUser } from "@fortawesome/free-solid-svg-icons";
 import { faCouch } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { format } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import { UserCountLayout } from "./userCountLayout";
 
 type apiResponse = {
@@ -28,6 +28,7 @@ type apiResponse = {
 export default async function UserDisplay() {
 	const now = new Date();
 	const hour = now.getHours();
+	const day = now.getDay();
 
 	let total: number | "---";
 	let note: string | undefined;
@@ -36,7 +37,7 @@ export default async function UserDisplay() {
 	let icon = 0;
 	let sofaCount = 0;
 
-	if (hour >= 10 && hour < 17) {
+	if (day >= 1 && day <= 5 && hour >= 10 && hour < 17) {
 		const url =
 			"https://script.google.com/macros/s/AKfycbzANLahldgD9yJ2Rf2xxN1sHUNtgXAeBEmjkQBPVQSdSs5gRQaY0CuPUwE5CeDSxrYH-Q/exec?limit=1";
 		const res = await fetch(url, { cache: "no-store" });
@@ -86,7 +87,11 @@ export default async function UserDisplay() {
 			sofaCongestion = "ソファ空きなし";
 		}
 
-		note = format(new Date(data[0].createdAt), "MM/dd HH:mm");
+		note = formatInTimeZone(
+			new Date(data[0].createdAt),
+			"Asia/Tokyo",
+			"MM/dd HH:mm",
+		);
 	} else {
 		total = "---";
 	}


### PR DESCRIPTION
## チェック
- [x] 余計な差分は存在しないか？

## 実装内容
- 現在時刻判定に、タイムゾーンを追加しました
- 10:00～17：00の間にアクセスがあったらAPIを叩きに行く処理でしたが、これだと土日にアクセスされると金曜の最後の人数が出てしまうので、土日の判定を追加しました

## スクショ
なし

## issue
close 

## 懸念点
これでも夏休み・冬休みなどの長期休業中の平日は、人数が表示されます。
GAS側でいろいろできないか検討中（今回のデプロイには間に合わないので、神田さんマップを差し替えるときに、こっちもアップデートしたい）

